### PR TITLE
Small tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ NAME = ircserv
 
 SRC = src/main.cpp
 
+INCLUDE_DIR := include/
+
 OBJS = $(SRC:.cpp=.o)
 
 CC = c++
@@ -18,10 +20,10 @@ irssi:
 	docker rm -f irssi 2>/dev/null
 
 .cpp.o:
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -I$(INCLUDE_DIR) -c $< -o $@
 
 $(NAME): $(OBJS)
-	$(CC) $(OBJS) $(CFLAGS) -o $(NAME)
+	$(CC) $(OBJS) -I$(INCLUDE_DIR) $(CFLAGS) -o $(NAME)
 
 clean:
 	@$(RM) $(OBJS)

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -2,7 +2,6 @@
 
 #include <sys/poll.h>
 #include <sys/signal.h>
-#include <iostream>
 #include <string>
 
 class Server {

--- a/include/printing.hpp
+++ b/include/printing.hpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+#define PRINT(X) std::cout << X << "\n"
+#define ERROR(X) std::cerr << X << "\n"
+#define __FLUSH() std::cout << std::endl
+#define __ERRFLUSH() std::cerr << std::endl

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,21 +1,19 @@
-#include "../include/Server.hpp"
+#include "Server.hpp"
+#include <sstream>
 
 int is_valid_port(std::string input) {
-	try {
-		size_t idx = 0;
-		int number = stoi(input, &idx);
-		if (idx != input.size())
-			throw std::invalid_argument("Error: The value of the port is not integer.\n");
-		if (number < 1 || number > 65535) {
-			throw std::out_of_range("Error: The port number is out of range (1-65535).");
-		}
-		return number;
-	} catch (const std::invalid_argument& e) {
-		std::cerr << "Error: The value of the port is not integer." << std::endl;
-	} catch (const std::out_of_range& e) {
-		std::cout << "Error: The port number is out of range (1-65535)." << std::endl;
+	std::istringstream iss(input);
+	int portno;
+
+	iss >> portno;
+	if (iss.fail() || !iss.eof()) {
+		std::cerr << "Error: invalid port number. Please make sure that the input is an integer in the range (1->65535)." << std::endl;
+		return -1;
+	} else if (portno < 1 || portno > 65535) {
+		std::cerr << "Error: invalid port number. Please make sure that the input is an integer in the range (1->65535)." << std::endl;
+		return -1;
 	}
-	return -1;
+	return portno;
 }
 
 int main(int argc, char *argv[]) {
@@ -23,7 +21,7 @@ int main(int argc, char *argv[]) {
 		std::cerr << "Usage: ./ircserv port password" << std::endl;
 		return 1;
 	}
-	std::string input = argv[1];
+	std::string input(argv[1]);
 	int port = is_valid_port(input);
 	if (port == -1)
 		return 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include "Server.hpp"
+#include "printing.hpp"
 #include <sstream>
 
 int is_valid_port(std::string input) {
@@ -7,10 +8,10 @@ int is_valid_port(std::string input) {
 
 	iss >> portno;
 	if (iss.fail() || !iss.eof()) {
-		std::cerr << "Error: invalid port number. Please make sure that the input is an integer in the range (1->65535)." << std::endl;
+		ERROR("Error: invalid port number. Please make sure that the input is an integer in the range (1->65535).");
 		return -1;
 	} else if (portno < 1 || portno > 65535) {
-		std::cerr << "Error: invalid port number. Please make sure that the input is an integer in the range (1->65535)." << std::endl;
+		ERROR("Error: invalid port number. Please make sure that the input is an integer in the range (1->65535).");
 		return -1;
 	}
 	return portno;


### PR DESCRIPTION
# 1. Refactored `is_valid_port()` function to have more wide-support.

## Reasons:
- `stoi()` function cannot be recognized on my machine. The use of `std::istringstream` allows for more elegant error-handling, and wider-support across platforms.
- It is better to reserve `try/catch` for actual run-time and complicated errors because the use of which introduces unnecessary overhead. It is also customary for functions that throw to be handled outside of their scope.
- using the `std::string(char*)` constructor results in one less function call behind the scenes, I think.

# 2. Added `-Iinclude/` in Makefile.

## Reasons:
- It allows us to include header-files without needing the full path, and automatically searches the include directory provided.
- A more modular approach means we won't have to worry about moving as many things around if we decided to change locations, names, and such.

# 3. Added printing macros to separate everything nicely

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced output and error messaging now provide clearer, consistent feedback to users.
  
- **Bug Fixes**
  - Refined validation for port input ensures only valid port numbers (1–65535) are accepted, reducing unexpected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->